### PR TITLE
add compatibility with redux-thunk extraArgument

### DIFF
--- a/src/Thunk.js
+++ b/src/Thunk.js
@@ -11,7 +11,7 @@ function createDispatchedObject(action) {
   };
 }
 
-export default function(thunkFunction) {
+export default function(thunkFunction, extraArgument) {
   const dispatches = [];
   let state;
   let originalState;
@@ -30,7 +30,7 @@ export default function(thunkFunction) {
 
   function executeDispatch(action) {
     if (_.isFunction(action)) {
-      return action(dispatch, getState);
+      return action(dispatch, getState, extraArgument);
     }
     error = new Error('provided action is not a thunk function');
     return null;


### PR DESCRIPTION
Since redux-thunk v2.1.0 we have ability to [provide extra argument](https://github.com/gaearon/redux-thunk/releases/tag/v2.1.0). It would be great to have it for tests.