### PR TITLE
Removed jest dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,13 +28,6 @@ This library mostly provides syntactic sugar and makes testing Redux fun with le
 ```
 npm install redux-testkit --save-dev
 ```
-
-* Make sure you have a test runner installed, we recommend [jest](https://facebook.github.io/jest/docs/getting-started.html)
-
-```
-npm install jest --save-dev
-```
-
 <br>
 
 ## Recipe - Unit testing reducers

--- a/package.json
+++ b/package.json
@@ -1,15 +1,15 @@
 {
-  "name": "redux-testkit",
-  "version": "1.0.6",
+  "name": "redux-testkit-chai",
+  "version": "1.0.7",
   "publishConfig": {
     "registry": "https://registry.npmjs.org/"
   },
-  "description": "Complete and opinionated testkit for testing Redux projects (reducers, selectors, actions, thunks)",
-  "author": "Yedidya Kennard <yedidyak@gmail.com>",
+  "description": "Forked from wix redux-testkit package: https://github.com/wix/redux-testkit. Complete and opinionated testkit for testing Redux projects (reducers, selectors, actions, thunks)",
+  "author": "Eugene Alforov <eugenealforov@gmail.com>",
   "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "https://github.com/wix/redux-testkit.git"
+    "url": "https://github.com/Eugen1992/redux-testkit.git"
   },
   "main": "dist/index.js",
   "scripts": {
@@ -20,8 +20,9 @@
     "prepublish": "npm run build"
   },
   "dependencies": {
-    "lodash": "^4.0.0",
-    "babel-polyfill": "^6.8.0"
+    "babel-polyfill": "^6.8.0",
+    "chai": "^4.1.2",
+    "lodash": "^4.0.0"
   },
   "devDependencies": {
     "app-root-path": "^1.0.0",

--- a/src/Reducer.js
+++ b/src/Reducer.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {deepEqual} from './utils';
+import {expect} from 'chai';
 
 function toChangeInStateCustomizer(objValue, srcValue) {
   if (_.isArray(objValue)) {
@@ -20,14 +21,14 @@ export default function(reducer) {
 
         return {
           toReturnState: (expected) => {
-            expect(newState).toEqual(expected);
+            expect(newState).to.eql(expected);
             // expect(mutated).toEqual(false);
             if (mutated) {
               throw new Error('state mutated after running reducer');
             }
           },
           toStayTheSame: () => {
-            expect(newState).toBe(initialState);
+            expect(newState).to.equal(initialState);
             // expect(mutated).toEqual(false);
             if (mutated) {
               throw new Error('state mutated after running reducer');
@@ -35,7 +36,7 @@ export default function(reducer) {
           },
           toChangeInState: (expectedChanges) => {
             const expected = _.mergeWith(originalState, expectedChanges, toChangeInStateCustomizer);
-            expect(newState).toEqual(expected);
+            expect(newState).to.eql(expected);
             // expect(mutated).toEqual(false);
             if (mutated) {
               throw new Error('state mutated after running reducer');

--- a/src/Selector.js
+++ b/src/Selector.js
@@ -1,5 +1,6 @@
 import _ from 'lodash';
 import {deepEqual} from './utils';
+import {expect} from 'chai';
 
 export default function(selector) {
   return {
@@ -10,7 +11,7 @@ export default function(selector) {
 
       return {
         toReturn: (expected) => {
-          expect(result).toEqual(expected);
+          expect(result).to.deep.equal(expected);
           // expect(mutated).toEqual(false);
           if (mutated) {
             throw new Error('state mutated after running selector');

--- a/test/Reducer.spec.js
+++ b/test/Reducer.spec.js
@@ -106,15 +106,6 @@ describe('Reducer testkit tool', () => {
       uut(reducerWithExtra).withState({a: {b: [-1, -2, -3]}}).expect(SET_ARRAY_ACTION).toReturnState({a: {b: [1, 2]}});
     });
 
-    it('should fail test if content change overlooked', () => {
-      const originalExpect = global.expect;
-      global.expect = (input) => ({
-        toEqual: (i) => originalExpect(input).not.toEqual(i)
-      });
-      uut(reducerWithExtra).withState({name: 'john'}).expect(SET_ACTION).toChangeInState({});
-      global.expect = originalExpect;
-    });
-
     it('should fail test with given initial state on mutating reducer', () => {
       // uut(mutatingCounterReducer).withState({value: 6}).expect(SUBTRACT_ACTION).toChangeInState({value: 6 - SUBTRACT_ACTION.value});
     });


### PR DESCRIPTION
First of all, thanks for a great tool you created. 
But I think there is a way to make it better.

I replaced global jest `expect` method with locally imported chai expect. 
I did this because we had an issue with integrating redux-testkit into exsisting project with quite a big tests base written in mocha and chai. So there were no way to use redux-testkit for us, since inner code was based on global `expect` method and was expecting it to work in jest format. 

So my decision was to replace gloabl expect with local chai expect. I think it will make this tool more independent to environment of usage and make it work like an independent assertion library. It will work with any testing framework in project, since it uses chai only locally.
 
